### PR TITLE
Schema tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,4 +2,4 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.5" % "test"
 
 libraryDependencies += "org.apache.httpcomponents" % "httpclient" % "4.3.4"
 
-libraryDependencies += "com.typesafe.play" %% "play-json" % "2.4.0-M3"
+libraryDependencies += "com.typesafe.play" %% "play-json" % "2.3.2"

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.5" % "test"
 
 libraryDependencies += "org.apache.httpcomponents" % "httpclient" % "4.3.4"
+
+libraryDependencies += "com.typesafe.play" %% "play-json" % "2.4.0-M3"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,7 @@
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
 addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.5")
+
+resolvers := Seq(Classpaths.typesafeResolver,
+  "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
+)

--- a/src/test/scala/test/SeoSanityTest.scala
+++ b/src/test/scala/test/SeoSanityTest.scala
@@ -1,0 +1,74 @@
+package test
+
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+
+
+class SeoSanityTest extends FlatSpec with ShouldMatchers with Http {
+
+  // caching coming through Fastly
+  val HtmlCacheControl = """max-age=(\d+), stale-while-revalidate=(\d+), stale-if-error=(\d+), private""".r
+  val AjaxCacheControl = """max-age=(\d+), stale-while-revalidate=(\d+), stale-if-error=(\d+), private""".r
+
+  "www.theguardian.com" should "serve with correct headers with no gzip" in {
+
+    val connection = GET(
+      s"http://www.theguardian.com/uk?view=mobile",
+      compress = false
+    )
+
+    connection.body should include("The Guardian")
+
+    connection.header("Vary") should be ("Accept-Encoding,User-Agent")
+    connection.header("Content-Type") should be ("text/html; charset=utf-8")
+    connection.header("X-GU-Platform") should be ("next-gen-router")
+    connection.responseCode should be (200)
+    connection.header("Cache-Control") match {
+      case HtmlCacheControl(maxAge, _, _) =>
+        maxAge.toInt should be > 0
+      case bad => fail("Bad cache control" + bad)
+    }
+  }
+
+  it should "serve with correct headers with gzip" in {
+
+    val connection = GET(
+      s"http://www.theguardian.com/uk?view=mobile",
+      compress = true
+    )
+
+    connection.bodyFromGzip should include("The Guardian")
+
+    connection.header("Vary") should be ("Accept-Encoding,User-Agent")
+    connection.header("Content-Type") should be ("text/html; charset=utf-8")
+    connection.header("X-GU-Platform") should be ("next-gen-router")
+    connection.responseCode should be (200)
+    connection.header("Cache-Control") match {
+      case HtmlCacheControl(maxAge, _, _) => maxAge.toInt should be > 0
+      case bad => fail("Bad cache control" + bad)
+    }
+  }
+
+  it should "compress json" in {
+    val connection = GET(
+      s"http://api.nextgen.guardianapps.co.uk/most-read/world.json",
+      compress = true,
+      headers = Seq(
+        "Accept" -> "application/json",
+        "Origin" -> "http://www.theguardian.com"
+      )
+    )
+
+    connection.body should include("""{"html":""")
+
+    connection.responseCode should be (200)
+    connection.header("Content-Type") should be ("application/json; charset=utf-8")
+    connection.header("Cache-Control") match {
+      case AjaxCacheControl(maxAge, _, _) => maxAge.toInt should be > 0
+      case bad => fail("Bad cache control" + bad)
+    }
+    connection.header("Vary") should be ("Accept-Encoding,Origin,Accept")
+  }
+}
+
+

--- a/src/test/scala/test/SeoSanityTest.scala
+++ b/src/test/scala/test/SeoSanityTest.scala
@@ -1,10 +1,10 @@
 package test
 
-import org.scalatest.FlatSpec
+import org.scalatest.{OptionValues, FlatSpec}
 import org.scalatest.matchers.ShouldMatchers
 import play.api.libs.json._
 
-class SeoSanityTest extends FlatSpec with ShouldMatchers with Http {
+class SeoSanityTest extends FlatSpec with ShouldMatchers with Http with OptionValues {
 
   def checkUrl(url: String): Unit = {
     val connection = GET(
@@ -17,10 +17,10 @@ class SeoSanityTest extends FlatSpec with ShouldMatchers with Http {
 
     val json: JsValue = Json.parse(connection.body)
 
-    val messages = (json \ "messages").as[JsArray].value
+    val messages = (json \ "messages").asOpt[JsArray]
 
-    withClue(s"${messages.toSeq.mkString("\n")}\n") {
-      messages.size should be(0)
+    withClue(s"${messages.value.as[Seq[String]].mkString("\n")}\n") {
+      messages.value.value.size should be(0)
     }
   }
 

--- a/src/test/scala/test/SeoSanityTest.scala
+++ b/src/test/scala/test/SeoSanityTest.scala
@@ -2,73 +2,53 @@ package test
 
 import org.scalatest.FlatSpec
 import org.scalatest.matchers.ShouldMatchers
-
+import play.api.libs.json._
 
 class SeoSanityTest extends FlatSpec with ShouldMatchers with Http {
 
-  // caching coming through Fastly
-  val HtmlCacheControl = """max-age=(\d+), stale-while-revalidate=(\d+), stale-if-error=(\d+), private""".r
-  val AjaxCacheControl = """max-age=(\d+), stale-while-revalidate=(\d+), stale-if-error=(\d+), private""".r
-
-  "www.theguardian.com" should "serve with correct headers with no gzip" in {
-
+  def checkUrl(url: String): Unit = {
     val connection = GET(
-      s"http://www.theguardian.com/uk?view=mobile",
-      compress = false
-    )
-
-    connection.body should include("The Guardian")
-
-    connection.header("Vary") should be ("Accept-Encoding,User-Agent")
-    connection.header("Content-Type") should be ("text/html; charset=utf-8")
-    connection.header("X-GU-Platform") should be ("next-gen-router")
-    connection.responseCode should be (200)
-    connection.header("Cache-Control") match {
-      case HtmlCacheControl(maxAge, _, _) =>
-        maxAge.toInt should be > 0
-      case bad => fail("Bad cache control" + bad)
-    }
-  }
-
-  it should "serve with correct headers with gzip" in {
-
-    val connection = GET(
-      s"http://www.theguardian.com/uk?view=mobile",
-      compress = true
-    )
-
-    connection.bodyFromGzip should include("The Guardian")
-
-    connection.header("Vary") should be ("Accept-Encoding,User-Agent")
-    connection.header("Content-Type") should be ("text/html; charset=utf-8")
-    connection.header("X-GU-Platform") should be ("next-gen-router")
-    connection.responseCode should be (200)
-    connection.header("Cache-Control") match {
-      case HtmlCacheControl(maxAge, _, _) => maxAge.toInt should be > 0
-      case bad => fail("Bad cache control" + bad)
-    }
-  }
-
-  it should "compress json" in {
-    val connection = GET(
-      s"http://api.nextgen.guardianapps.co.uk/most-read/world.json",
+      s"http://linter.structured-data.org/?url=$url",
       compress = true,
       headers = Seq(
-        "Accept" -> "application/json",
-        "Origin" -> "http://www.theguardian.com"
+        "Accept" -> "application/json"
       )
     )
 
-    connection.body should include("""{"html":""")
+    val json: JsValue = Json.parse(connection.body)
 
-    connection.responseCode should be (200)
-    connection.header("Content-Type") should be ("application/json; charset=utf-8")
-    connection.header("Cache-Control") match {
-      case AjaxCacheControl(maxAge, _, _) => maxAge.toInt should be > 0
-      case bad => fail("Bad cache control" + bad)
+    val messages = (json \ "messages").as[JsArray].value
+
+    withClue(s"${messages.toSeq.mkString("\n")}\n") {
+      messages.size should be(0)
     }
-    connection.header("Vary") should be ("Accept-Encoding,Origin,Accept")
+  }
+
+  "The network front" should "serve correct and valid seo meta data" in {
+      checkUrl("http://www.theguardian.com/uk")
+  }
+
+  "Tag pages" should "serve correct and valid seo meta data" in {
+    checkUrl("http://www.theguardian.com/world/series/guardian-world-networks")
+  }
+
+  "Article pages" should "serve correct and valid seo meta data" in {
+    checkUrl("http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit")
+  }
+
+  "Live blogs" should "serve correct and valid seo meta data" in {
+    checkUrl("http://www.theguardian.com/politics/live/2015/apr/17/election-2015-live-ed-miliband-nicola-sturgeon-david-cameron-snp-labour")
+  }
+
+  "Gallery pages" should "serve correct and valid seo meta data" in {
+    checkUrl("http://www.theguardian.com/artanddesign/gallery/2015/apr/15/postcards-from-the-ruins-the-desolate-edge-of-eastern-europe-tamas-dezso-in-pictures")
+  }
+
+  "Video pages" should "serve correct and valid seo meta data" in {
+    checkUrl("http://www.theguardian.com/lifeandstyle/video/2015/apr/17/motivation-finish-studies-problem-agony-aunt-video")
+  }
+
+  "Interactive pages" should "serve correct and valid seo meta data" in {
+    checkUrl("http://www.theguardian.com/environment/ng-interactive/2015/apr/16/gates-foundation-wellcome-trust-climate-change-divest-fossil-fuels-guardian")
   }
 }
-
-

--- a/src/test/scala/test/SeoSanityTest.scala
+++ b/src/test/scala/test/SeoSanityTest.scala
@@ -37,7 +37,7 @@ class SeoSanityTest extends FlatSpec with ShouldMatchers with Http with OptionVa
   }
 
   "Live blogs" should "serve correct and valid seo meta data" in {
-    checkUrl("http://www.theguardian.com/politics/live/2015/apr/17/election-2015-live-ed-miliband-nicola-sturgeon-david-cameron-snp-labour")
+    checkUrl("http://www.theguardian.com/football/live/2015/apr/18/reading-arsenal-fa-cup-semi-final-live")
   }
 
   "Gallery pages" should "serve correct and valid seo meta data" in {


### PR DESCRIPTION
This adds a suite of new sanity tests to validate our Schema and linked data properties. This uses the open-source linter http://linter.structured-data.org/ to run the tests. More info can be found [here](http://linter.structured-data.org/about/)

And will produce output like:
![iterm](https://cloud.githubusercontent.com/assets/80089/7200463/25507e3c-e4f5-11e4-8d88-32ebe75bcaff.png)

I will not merge this until I've submitted a corresponding RP top the frontend repo to fix our current issues.

/cc @gklopper @rich-nguyen @robertberry 