### PR TITLE
review pages should serve valid review metadata too

### DIFF
--- a/src/test/scala/test/SeoSanityTest.scala
+++ b/src/test/scala/test/SeoSanityTest.scala
@@ -63,4 +63,9 @@ class SeoSanityTest extends FlatSpec with Matchers with Http with OptionValues {
   "Interactive pages" should "serve correct and valid seo meta data" in {
     checkUrl("http://www.theguardian.com/environment/ng-interactive/2015/apr/16/gates-foundation-wellcome-trust-climate-change-divest-fossil-fuels-guardian")
   }
+
+  "Review pages" should "serve correct and valid seo meta data" in {
+    checkUrl("http://www.theguardian.com/stage/2015/jun/01/the-elephant-man-review-bradley-cooper-london")
+  }
+
 }


### PR DESCRIPTION
We should test reviews serve valid metadata because they should be sending the star rating etc and have their own code paths.