### PR TITLE
filter out messages we aren't bothered about

### DIFF
--- a/src/test/scala/test/SeoSanityTest.scala
+++ b/src/test/scala/test/SeoSanityTest.scala
@@ -18,10 +18,26 @@ class SeoSanityTest extends FlatSpec with Matchers with Http with OptionValues {
 
     val messages = (json \ "messages").asOpt[JsArray].value.as[Seq[String]]
 
-    val filtered = filter(messages)
+    val filtered = filter(ignoreHtmlErrors(messages))
 
     withClue(s"${filtered.mkString("\n")}\n") {
       filtered.size should be(0)
+    }
+  }
+
+  /**
+   * this is needed because the validator validates just about everything even stuff we don't care about
+   * @param messages
+   */
+  def ignoreHtmlErrors(messages: Seq[String]) = {
+    val tag = ".*: Tag [^ ]* invalid".r
+    val entity = ".*: htmlParseEntityRef: .*".r
+    val scriptWithClose = ".*: Element script embeds close tag".r
+    messages.filter {
+      case tag() => false
+      case entity() => false
+      case scriptWithClose() => false
+      case _ => true
     }
   }
 


### PR DESCRIPTION
We get a load of messages from the linter that we're not actually bothered about (maybe we should be, but it's probably not the priority)
Just this ignores all the ones except the class double definition, which is fixed in https://github.com/guardian/frontend/pull/9449
```
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: Element script embeds close tag
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: Tag svg invalid
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: Tag path invalid
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: Tag header invalid
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: Attribute class redefined
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: Tag circle invalid
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: Tag nav invalid
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: Tag article invalid
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: Tag figure invalid
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: Tag figcaption invalid
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: Tag aside invalid
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: Tag section invalid
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: Tag footer invalid
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: htmlParseEntityRef: no name
validation http://www.theguardian.com/politics/commentisfree/2015/apr/16/tv-opposition-leaders-debate-spin-room-westminster-artless-bullshit: htmlParseEntityRef: expecting ';'
```